### PR TITLE
M2M attr: sibling-attribute filtering (sqlite3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ACCOUNT=gaf3
 IMAGE=python-relations-sqlite3
 INSTALL=python:3.8.5-alpine3.12
-VERSION?=0.6.8
+VERSION?=0.6.9
 DEBUG_PORT=5678
 TTY=$(shell if tty -s; then echo "-it"; fi)
 VOLUMES=-v ${PWD}/lib:/opt/service/lib \

--- a/lib/relations_sqlite3.py
+++ b/lib/relations_sqlite3.py
@@ -29,7 +29,9 @@ class Source(relations_sql.SOURCE, relations.Source): # pylint: disable=too-many
     OP = relations_sqlite.OP
 
     AS = relations_sqlite.AS
+    OPTIONS = relations_sqlite.OPTIONS
     FIELDS = relations_sqlite.FIELDS
+    COLUMN_NAME = relations_sqlite.COLUMN_NAME
     TABLE = relations_sqlite.TABLE
     TABLE_NAME = relations_sqlite.TABLE_NAME
 
@@ -278,6 +280,11 @@ class Source(relations_sql.SOURCE, relations.Source): # pylint: disable=too-many
         self.retrieve_record(model._record, query)
         self.like(model, query)
 
+        # a sibling-attribute flat join repeats a model tied to several matching siblings, so
+        # count the distinct model id instead of the joined rows
+        if getattr(model, "_distinct", False):
+            query.FIELDS = self.FIELDS(self.AS("total", self.SQL(f"COUNT(DISTINCT {model.STORE}.{model._id})")))
+
         return query
 
     def retrieve_query(self, model):
@@ -287,7 +294,12 @@ class Source(relations_sql.SOURCE, relations.Source): # pylint: disable=too-many
 
         query = self.count_query(model)
 
-        query.FIELDS = self.FIELDS("*")
+        # honor the flat-join DISTINCT marker: dedupe the model rows the join multiplied
+        if getattr(model, "_distinct", False):
+            query.OPTIONS = self.OPTIONS("DISTINCT")
+            query.FIELDS = self.FIELDS(self.COLUMN_NAME("*", table=model.STORE))
+        else:
+            query.FIELDS = self.FIELDS("*")
 
         self.sort(model, query)
         self.limit(model, query)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 
-relations-dil @ git+https://github.com/relations-dil/python-relations@aa309087789d4b7ed459676c4343f61bb95a4af5
-relations-sql @ git+https://github.com/relations-dil/python-relations-sql@7d8be2cfa9921a3321a123fa668640002b031f9e
+relations-dil==0.6.15
+relations-sql==0.6.9
 relations-sqlite==0.6.3
 ptvsd==4.3.2
 coverage==5.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 
-relations-dil==0.6.14
-relations-sql==0.6.8
+relations-dil @ git+https://github.com/relations-dil/python-relations@aa309087789d4b7ed459676c4343f61bb95a4af5
+relations-sql @ git+https://github.com/relations-dil/python-relations-sql@7d8be2cfa9921a3321a123fa668640002b031f9e
 relations-sqlite==0.6.3
 ptvsd==4.3.2
 coverage==5.2.1

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name="relations-sqlite3",
-    version="0.6.8",
+    version="0.6.9",
     package_dir = {'': 'lib'},
     py_modules = [
         'relations_sqlite3'

--- a/test/test_relations_sqlite3.py
+++ b/test/test_relations_sqlite3.py
@@ -917,6 +917,52 @@ LIMIT ?""")
         self.assertEqual(Bro.many(sis_id__all=[jane.id, joan.id]).name, ["Bob"])
         self.assertEqual(Bro.many(sis_id__any=[joan.id]).name, ["Bob"])
 
+    def test_retrieve_ties_attr(self):
+
+        self.source.execute(Sis.define())
+        self.source.execute(Bro.define())
+        self.source.execute(SisBro.define())
+
+        # M2M attribute filtering: a flat join through the tie table filters on the sibling's
+        # own field. Existence semantics, with the sibling's normal field operators.
+
+        tom = Bro("Tom").create()
+        dick = Bro("Dick").create()
+        harry = Bro("Harry").create()
+
+        Sis("Mary", bro_id=[tom.id, dick.id]).create()   # tied to Tom, Dick
+        Sis("Sue", bro_id=[tom.id]).create()             # tied to Tom
+        Sis("Ann", bro_id=[dick.id, harry.id]).create()  # tied to Dick, Harry
+
+        # tied to a brother with that name
+        self.assertEqual(sorted(Sis.many(bro__name="Tom").name), ["Mary", "Sue"])
+        self.assertEqual(Sis.many(bro__name="Harry").name, ["Ann"])
+        self.assertEqual(len(Sis.many(bro__name="Ghost")), 0)
+
+        # field operators land on the sibling: like
+        self.assertEqual(Sis.many(bro__name__like="arr").name, ["Ann"])
+
+        # DISTINCT: Mary is tied to BOTH Tom and Dick, so an "in" join would match her twice;
+        # she must appear once (retrieve) and count once
+        self.assertEqual(sorted(Sis.many(bro__name__in=["Tom", "Dick"]).name), ["Ann", "Mary", "Sue"])
+        self.assertEqual(Sis.many(bro__name__in=["Tom", "Dick"]).count(), 3)
+
+        # negation is field-level: a tied non-Tom exists (Mary stays via Dick)
+        self.assertEqual(sorted(Sis.many(bro__name__not_in=["Tom"]).name), ["Ann", "Mary"])
+
+        # criteria on the same relation filter the SAME tied brother
+        self.assertEqual(Sis.many(bro__name="Dick", bro__id=harry.id).name, [])
+        self.assertEqual(sorted(Sis.many(bro__name="Dick", bro__id=dick.id).name), ["Ann", "Mary"])
+
+        # symmetric: brothers filtered by a tied sister's name
+        jane = Sis("Jane").create()
+        joan = Sis("Joan").create()
+        Bro("Bab", sis_id=[jane.id, joan.id]).create()   # tied to Jane, Joan
+        Bro("Bil", sis_id=[jane.id]).create()            # tied to Jane
+
+        self.assertEqual(sorted(Bro.many(sis__name="Jane").name), ["Bab", "Bil"])
+        self.assertEqual(Bro.many(sis__name__in=["Joan"]).name, ["Bab"])
+
     def test_titles(self):
 
         self.source.execute(Unit.define())


### PR DESCRIPTION
## M2M attr — sibling-attribute filtering (sqlite3)

Resolves `Sis.many(bro__name="Tom")` end-to-end against SQLite, on top of relations-dil#69 and relations-sql#23.

- Honors the flat-join `_distinct` marker: `count_query` → `COUNT(DISTINCT id)`, `retrieve_query` → `SELECT DISTINCT model.*` (only when an attr join was added; normal queries untouched).
- Adds `COLUMN_NAME` + `OPTIONS` to the Source (the shared mixin needs `COLUMN_NAME`).
- Functional test on a real DB including the DISTINCT case: a sister tied to both Tom and Dick → `bro__name__in=["Tom","Dick"]` returns her once, counts 3.

Pinned to `relations-dil==0.6.15`, `relations-sql==0.6.9`. Gates green: build → test (31, 100%) → lint (10.00) → setup.

Closes #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
